### PR TITLE
Add formatDurationByOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ console.log(formattedDateTimeWithOptions); // Outputs: "Jan 1, 2024, 12:00 PM"
 // Format a duration
 const duration = dateTime.formatDuration(new Date(2024, 0, 1), new Date(2024, 0, 2), 'en-US');
 console.log(duration); // Outputs: "1 day 1 hour 1 minute 1 second"
+
+// Format a duration with custom options
+const durationWithOptions = dateTime.formatDurationByOptions(
+  { unitDisplay: 'narrow' }, 
+  new Date(2024, 0, 1), 
+  new Date(2024, 0, 2), 
+  'en-US'
+);
+console.log(durationWithOptions); // Outputs: "1d 1h 1m 1s"
 ```
 
 ## Installation

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,4 @@
 import * as dateTime from './index';
-import { formatDurationByOptions } from './index';
 
 const dates = [
     {
@@ -425,7 +424,7 @@ describe('date-time', () => {
             const options: Intl.NumberFormatOptions = { 
                 unitDisplay: 'long',
             }
-          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hour 2 minutes 3 seconds');
+          expect(dateTime.formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hour 2 minutes 3 seconds');
         });
       
         test('with compact notation', () => {
@@ -433,7 +432,7 @@ describe('date-time', () => {
             notation: 'compact',
             style: 'unit'
           };
-          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hr 2 min 3 sec');
+          expect(dateTime.formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hr 2 min 3 sec');
         });
       
         test('with different unit style', () => {
@@ -441,18 +440,18 @@ describe('date-time', () => {
             style: 'unit',
             unitDisplay: 'narrow'
           };
-          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1h 2m 3s');
+          expect(dateTime.formatDurationByOptions(options, baseDate, laterDate)).toBe('1h 2m 3s');
         });
 
         test('with different locale', () => {
             const options: Intl.NumberFormatOptions = {
                 unitDisplay: 'narrow',
             }
-            expect(formatDurationByOptions(options, baseDate, laterDate, 'en-US')).toBe('1h 2m 3s');
-            expect(formatDurationByOptions(options, baseDate, laterDate, 'zh-CN')).toBe('1小时 2分钟 3秒');
-            expect(formatDurationByOptions(options, baseDate, laterDate, 'ja-JP')).toBe('1h 2m 3s');
-            expect(formatDurationByOptions(options, baseDate, laterDate, 'ko-KR')).toBe('1시간 2분 3초');
-            expect(formatDurationByOptions(options, baseDate, laterDate, 'de-DE')).toBe('1 Std. 2 Min. 3 Sek.');
+            expect(dateTime.formatDurationByOptions(options, baseDate, laterDate, 'en-US')).toBe('1h 2m 3s');
+            expect(dateTime.formatDurationByOptions(options, baseDate, laterDate, 'zh-CN')).toBe('1小时 2分钟 3秒');
+            expect(dateTime.formatDurationByOptions(options, baseDate, laterDate, 'ja-JP')).toBe('1h 2m 3s');
+            expect(dateTime.formatDurationByOptions(options, baseDate, laterDate, 'ko-KR')).toBe('1시간 2분 3초');
+            expect(dateTime.formatDurationByOptions(options, baseDate, laterDate, 'de-DE')).toBe('1 Std. 2 Min. 3 Sek.');
         });
       });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import * as dateTime from './index';
+import { formatDurationByOptions } from './index';
 
 const dates = [
     {
@@ -415,4 +416,43 @@ describe('date-time', () => {
     test('should not format duration', () => {
         expect(dateTime.formatDuration(new Date(2000, 0, 2), new Date(2000, 0, 1), 'en-US')).toStrictEqual('');
     });
+
+    describe('formatDurationByOptions', () => {
+        const baseDate = new Date('2024-01-01T00:00:00Z');
+        const laterDate = new Date('2024-01-01T01:02:03Z');
+        
+        test('with default options', () => {
+            const options: Intl.NumberFormatOptions = { 
+                unitDisplay: 'long',
+            }
+          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hour 2 minutes 3 seconds');
+        });
+      
+        test('with compact notation', () => {
+          const options: Intl.NumberFormatOptions = {
+            notation: 'compact',
+            style: 'unit'
+          };
+          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1 hr 2 min 3 sec');
+        });
+      
+        test('with different unit style', () => {
+          const options: Intl.NumberFormatOptions = {
+            style: 'unit',
+            unitDisplay: 'narrow'
+          };
+          expect(formatDurationByOptions(options, baseDate, laterDate)).toBe('1h 2m 3s');
+        });
+
+        test('with different locale', () => {
+            const options: Intl.NumberFormatOptions = {
+                unitDisplay: 'narrow',
+            }
+            expect(formatDurationByOptions(options, baseDate, laterDate, 'en-US')).toBe('1h 2m 3s');
+            expect(formatDurationByOptions(options, baseDate, laterDate, 'zh-CN')).toBe('1小时 2分钟 3秒');
+            expect(formatDurationByOptions(options, baseDate, laterDate, 'ja-JP')).toBe('1h 2m 3s');
+            expect(formatDurationByOptions(options, baseDate, laterDate, 'ko-KR')).toBe('1시간 2분 3초');
+            expect(formatDurationByOptions(options, baseDate, laterDate, 'de-DE')).toBe('1 Std. 2 Min. 3 Sek.');
+        });
+      });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,10 +170,19 @@ export function formatDateTimeByOptions(options: Intl.DateTimeFormatOptions, dat
 }
 
 export function formatDuration(from: Date, to = new Date(), locale = getLocale()) {
+    return formatDurationByOptions({ unitDisplay: 'long' }, from, to, locale);
+}
+
+export function formatDurationByOptions(options: Intl.NumberFormatOptions, from: Date, to = new Date(), locale = getLocale()) {
+    if (!options) {
+        throw new Error('Please use formatDuration instead');
+    }
+
     const milliseconds = to.getTime() - from.getTime();
     if (milliseconds < 0) {
         return '';
     }
+
     const dayInMs = 24 * 60 * 60 * 1000;
     const hourInMs = 60 * 60 * 1000;
     const minuteInMs = 60 * 1000;
@@ -187,8 +196,8 @@ export function formatDuration(from: Date, to = new Date(), locale = getLocale()
     const getNumberFormat = (unit: string, number: number | bigint) =>
         new Intl.NumberFormat(locale, {
             style: 'unit',
-            unitDisplay: 'long',
             unit,
+            ...options,
         }).format(number);
 
     let result = '';


### PR DESCRIPTION
Add a new function formatDurationByOptions to allow for more granular control of options in the formatDuration function. Still backwards compatible for usages of formatDuration.